### PR TITLE
feat: add support for relative endpoint URLs

### DIFF
--- a/packages/astro-umami/src/index.ts
+++ b/packages/astro-umami/src/index.ts
@@ -109,10 +109,17 @@ async function getInjectableWebAnalyticsContent({
     withPartytown = false,
   } = options;
 
+  if (endpointUrl.startsWith("//")) {
+    throw new TypeError(
+      "`endpointUrl` must be an absolute URL or a root-relative path",
+    );
+  }
+
   const isRelativeEndpoint = endpointUrl.startsWith("/");
   const scriptSrc = isRelativeEndpoint
     ? `${endpointUrl.replace(/\/+$/, "")}/${trackerScriptName}`
     : `https://${new URL(endpointUrl).hostname}/${trackerScriptName}`;
+  const scriptSrcAsString = JSON.stringify(scriptSrc);
   const configAsString = [
     !autotrack ? `script.setAttribute("data-auto-track", "${autotrack}")` : "",
     beforeSendHandler ? `script.setAttribute("data-before-send", "${beforeSendHandler}")` : "",
@@ -136,7 +143,7 @@ async function getInjectableWebAnalyticsContent({
     var script = document.createElement("script");
     var viewTransitionsEnabled = document.querySelector("meta[name='astro-view-transitions-enabled']")?.content;
 
-    script.setAttribute("src", "${scriptSrc}");
+    script.setAttribute("src", ${scriptSrcAsString});
     script.setAttribute("defer", true);
     script.setAttribute("data-website-id", "${id}");
     ${configAsString};

--- a/packages/astro-umami/src/index.ts
+++ b/packages/astro-umami/src/index.ts
@@ -85,6 +85,16 @@ interface Options extends UmamiOptions {
   withPartytown?: boolean;
 }
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+
+  while (end > 0 && value[end - 1] === "/") {
+    end -= 1;
+  }
+
+  return value.slice(0, end);
+}
+
 async function getInjectableWebAnalyticsContent({
   mode,
   options,
@@ -109,17 +119,22 @@ async function getInjectableWebAnalyticsContent({
     withPartytown = false,
   } = options;
 
-  if (endpointUrl.startsWith("//")) {
+  const isRelativeEndpoint = endpointUrl.startsWith("/");
+  const scriptSrc = isRelativeEndpoint
+    ? `${trimTrailingSlashes(endpointUrl)}/${trackerScriptName}`
+    : `https://${new URL(endpointUrl).hostname}/${trackerScriptName}`;
+
+  if (
+    isRelativeEndpoint
+    && new URL(scriptSrc, "https://astro-umami.invalid").origin
+    !== "https://astro-umami.invalid"
+  ) {
     throw new TypeError(
       "`endpointUrl` must be an absolute URL or a root-relative path",
     );
   }
 
-  const isRelativeEndpoint = endpointUrl.startsWith("/");
-  const scriptSrc = isRelativeEndpoint
-    ? `${endpointUrl.replace(/\/+$/, "")}/${trackerScriptName}`
-    : `https://${new URL(endpointUrl).hostname}/${trackerScriptName}`;
-  const scriptSrcAsString = JSON.stringify(scriptSrc);
+  const scriptSrcAsString = JSON.stringify(scriptSrc).replaceAll("<", "\\u003C");
   const configAsString = [
     !autotrack ? `script.setAttribute("data-auto-track", "${autotrack}")` : "",
     beforeSendHandler ? `script.setAttribute("data-before-send", "${beforeSendHandler}")` : "",

--- a/packages/astro-umami/src/index.ts
+++ b/packages/astro-umami/src/index.ts
@@ -27,10 +27,11 @@ interface UmamiOptions {
   doNotTrack?: boolean;
   /**
    *
-   * The endpoint where your Umami instance is located.
+   * The URL or root-relative path where your Umami instance is located.
    *
    * @default https://cloud.umami.is
    * @example https://umami-on.fly.dev
+   * @example /_umami
    */
   endpointUrl?: string;
   /**
@@ -108,7 +109,10 @@ async function getInjectableWebAnalyticsContent({
     withPartytown = false,
   } = options;
 
-  const hostname = new URL(endpointUrl).hostname;
+  const isRelativeEndpoint = endpointUrl.startsWith("/");
+  const scriptSrc = isRelativeEndpoint
+    ? `${endpointUrl.replace(/\/+$/, "")}/${trackerScriptName}`
+    : `https://${new URL(endpointUrl).hostname}/${trackerScriptName}`;
   const configAsString = [
     !autotrack ? `script.setAttribute("data-auto-track", "${autotrack}")` : "",
     beforeSendHandler ? `script.setAttribute("data-before-send", "${beforeSendHandler}")` : "",
@@ -132,7 +136,7 @@ async function getInjectableWebAnalyticsContent({
     var script = document.createElement("script");
     var viewTransitionsEnabled = document.querySelector("meta[name='astro-view-transitions-enabled']")?.content;
 
-    script.setAttribute("src", "https://${hostname}/${trackerScriptName}");
+    script.setAttribute("src", "${scriptSrc}");
     script.setAttribute("defer", true);
     script.setAttribute("data-website-id", "${id}");
     ${configAsString};

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,4 +1,5 @@
 .astro
+dist/
 node_modules/
 playwright-report/
 test-results/

--- a/playground/relative/astro.config.ts
+++ b/playground/relative/astro.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "astro/config";
+import { createIntegrationWatcher } from "../integrations/watcher";
+
+const { default: packageName } = await import("@yeskunall/astro-umami");
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [
+    packageName({
+      endpointUrl: "/_umami",
+      id: "94db1cb1-74f4-4a40-ad6c-962362670409",
+    }),
+    createIntegrationWatcher(
+      fileURLToPath(
+        new URL("../../packages/astro-umami/dist", import.meta.url),
+      ),
+    ),
+  ],
+  server: {
+    port: 4323,
+  },
+});

--- a/playground/relative/astro.config.ts
+++ b/playground/relative/astro.config.ts
@@ -1,14 +1,16 @@
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import { createIntegrationWatcher } from "../integrations/watcher";
 
 const { default: packageName } = await import("@yeskunall/astro-umami");
+const endpointUrl = process.env.UMAMI_ENDPOINT_URL ?? "/_umami";
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [
     packageName({
-      endpointUrl: "/_umami",
+      endpointUrl,
       id: "94db1cb1-74f4-4a40-ad6c-962362670409",
     }),
     createIntegrationWatcher(

--- a/playground/relative/package.json
+++ b/playground/relative/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "playground-relative",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "astro check && astro build",
+    "dev": "astro dev",
+    "preview": "astro preview",
+    "start": "astro dev",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "@yeskunall/astro-umami": "workspace:*",
+    "astro": "7.1.6"
+  },
+  "devDependencies": {
+    "@astrojs/check": "0.9.10",
+    "@playwright/test": "1.62.0",
+    "@types/node": "26.1.2",
+    "playwright": "1.62.0",
+    "typescript": "catalog:"
+  }
+}

--- a/playground/relative/playwright.config.ts
+++ b/playground/relative/playwright.config.ts
@@ -1,0 +1,25 @@
+import process from "node:process";
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests",
+  fullyParallel: true,
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], channel: "chromium" },
+    },
+  ],
+  reporter: "html",
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: "http://localhost:4323",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:4323",
+    reuseExistingServer: !process.env.CI,
+  },
+  workers: process.env.CI ? 1 : undefined,
+});

--- a/playground/relative/src/env.d.ts
+++ b/playground/relative/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/playground/relative/src/pages/index.astro
+++ b/playground/relative/src/pages/index.astro
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+
+		<title>Relative endpoint playground</title>
+	</head>
+	<body>
+	</body>
+</html>

--- a/playground/relative/tests/index.spec.ts
+++ b/playground/relative/tests/index.spec.ts
@@ -1,4 +1,25 @@
+import { execFile } from "node:child_process";
+import { readFile, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { Script } from "node:vm";
 import { expect, test } from "@playwright/test";
+
+const execFileAsync = promisify(execFile);
+const playgroundDirectory = fileURLToPath(new URL("..", import.meta.url));
+const outputDirectory = new URL("../dist/", import.meta.url);
+
+async function buildWithEndpoint(endpointUrl: string): Promise<string> {
+  await execFileAsync("pnpm", ["exec", "astro", "build"], {
+    cwd: playgroundDirectory,
+    env: {
+      ...process.env,
+      UMAMI_ENDPOINT_URL: endpointUrl,
+    },
+  });
+
+  return readFile(new URL("index.html", outputDirectory), "utf8");
+}
 
 test("uses the relative endpoint for the tracker script", async ({ page }) => {
   await page.route("**/_umami/script.js", async (route) => {
@@ -74,4 +95,40 @@ test("does not request the Cloud Umami endpoint", async ({ page }) => {
   await page.goto("/");
 
   expect(cloudRequests).toHaveLength(0);
+});
+
+test("rejects protocol-relative endpoint URLs", async () => {
+  let stderr: string | undefined;
+
+  try {
+    await buildWithEndpoint("//analytics.example.com");
+  }
+  catch (error) {
+    stderr = (error as { stderr?: string }).stderr;
+  }
+  finally {
+    await rm(outputDirectory, { force: true, recursive: true });
+  }
+
+  expect(stderr).toContain(
+    "`endpointUrl` must be an absolute URL or a root-relative path",
+  );
+});
+
+test("escapes the endpoint URL in the generated inline script", async () => {
+  try {
+    const html = await buildWithEndpoint(
+      String.raw`/_umami";window.__INJECTED__=true;//`,
+    );
+    const inlineScript = html.match(/<script>([\s\S]*?)<\/script>/u)?.[1];
+
+    if (inlineScript === undefined) {
+      throw new Error("Expected the build output to contain an inline script");
+    }
+
+    expect(() => new Script(inlineScript)).not.toThrow();
+  }
+  finally {
+    await rm(outputDirectory, { force: true, recursive: true });
+  }
 });

--- a/playground/relative/tests/index.spec.ts
+++ b/playground/relative/tests/index.spec.ts
@@ -23,6 +23,30 @@ async function buildWithEndpoint(endpointUrl: string): Promise<string> {
   return readFile(new URL("index.html", outputDirectory), "utf8");
 }
 
+async function getBuildError(endpointUrl: string): Promise<string | undefined> {
+  try {
+    await buildWithEndpoint(endpointUrl);
+  }
+  catch (error) {
+    return (error as { stderr?: string }).stderr;
+  }
+  finally {
+    await rm(outputDirectory, { force: true, recursive: true });
+  }
+}
+
+function getInlineScript(html: string): string {
+  const openingTag = "<script>";
+  const start = html.indexOf(openingTag);
+  const end = html.indexOf("</script>", start + openingTag.length);
+
+  if (start === -1 || end === -1) {
+    throw new Error("Expected the build output to contain an inline script");
+  }
+
+  return html.slice(start + openingTag.length, end);
+}
+
 test("uses the relative endpoint for the tracker script", async ({ page }) => {
   await page.route("**/_umami/script.js", async (route) => {
     await route.fulfill({
@@ -100,33 +124,27 @@ test("does not request the Cloud Umami endpoint", async ({ page }) => {
 });
 
 test("rejects protocol-relative endpoint URLs", async () => {
-  let stderr: string | undefined;
-
-  try {
-    await buildWithEndpoint("//analytics.example.com");
-  }
-  catch (error) {
-    stderr = (error as { stderr?: string }).stderr;
-  }
-  finally {
-    await rm(outputDirectory, { force: true, recursive: true });
-  }
+  const stderr = await getBuildError("//analytics.example.com");
 
   expect(stderr).toContain(
     "`endpointUrl` must be an absolute URL or a root-relative path",
   );
 });
 
-test("escapes the endpoint URL in the generated inline script", async () => {
+test("rejects backslash network-path endpoint URLs", async () => {
+  const stderr = await getBuildError(String.raw`/\analytics.example.com`);
+
+  expect(stderr).toContain(
+    "`endpointUrl` must be an absolute URL or a root-relative path",
+  );
+});
+
+test("escapes HTML script terminators in the endpoint URL", async () => {
   try {
     const html = await buildWithEndpoint(
-      String.raw`/_umami";window.__INJECTED__=true;//`,
+      String.raw`/_umami";</script><script>window.__INJECTED__=true</script>`,
     );
-    const inlineScript = html.match(/<script>([\s\S]*?)<\/script>/u)?.[1];
-
-    if (inlineScript === undefined) {
-      throw new Error("Expected the build output to contain an inline script");
-    }
+    const inlineScript = getInlineScript(html);
 
     expect(() => new Script(inlineScript)).not.toThrow();
   }

--- a/playground/relative/tests/index.spec.ts
+++ b/playground/relative/tests/index.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+test("uses the relative endpoint for the tracker script", async ({ page }) => {
+  await page.route("**/_umami/script.js", async (route) => {
+    await route.fulfill({
+      body: "",
+      contentType: "application/javascript",
+      status: 200,
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("script[data-website-id]")).toHaveAttribute(
+    "src",
+    "/_umami/script.js",
+  );
+});
+
+test("omits `data-host-url` for a relative endpoint by default", async ({ page }) => {
+  await page.route("**/_umami/script.js", async (route) => {
+    await route.fulfill({
+      body: "",
+      contentType: "application/javascript",
+      status: 200,
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("script[data-website-id]")).not.toHaveAttribute(
+    "data-host-url",
+    /.+/,
+  );
+});
+
+test("loads the tracker script from the page origin", async ({ page }) => {
+  let requestedUrl: string | undefined;
+
+  await page.route("**/_umami/script.js", async (route) => {
+    requestedUrl = route.request().url();
+    await route.fulfill({
+      body: "window.__UMAMI_TEST_LOADED__ = true;",
+      contentType: "application/javascript",
+      status: 200,
+    });
+  });
+
+  await page.goto("/");
+  await page.waitForFunction(
+    () => (window as typeof window & { __UMAMI_TEST_LOADED__?: boolean }).__UMAMI_TEST_LOADED__,
+  );
+
+  expect(requestedUrl).toBe("http://localhost:4323/_umami/script.js");
+});
+
+test("does not request the Cloud Umami endpoint", async ({ page }) => {
+  const cloudRequests: string[] = [];
+
+  page.on("request", (request) => {
+    if (request.url().includes("cloud.umami.is")) {
+      cloudRequests.push(request.url());
+    }
+  });
+
+  await page.route("**/_umami/script.js", async (route) => {
+    await route.fulfill({
+      body: "",
+      contentType: "application/javascript",
+      status: 200,
+    });
+  });
+
+  await page.goto("/");
+
+  expect(cloudRequests).toHaveLength(0);
+});

--- a/playground/relative/tests/index.spec.ts
+++ b/playground/relative/tests/index.spec.ts
@@ -9,6 +9,8 @@ const execFileAsync = promisify(execFile);
 const playgroundDirectory = fileURLToPath(new URL("..", import.meta.url));
 const outputDirectory = new URL("../dist/", import.meta.url);
 
+test.describe.configure({ mode: "serial" });
+
 async function buildWithEndpoint(endpointUrl: string): Promise<string> {
   await execFileAsync("pnpm", ["exec", "astro", "build"], {
     cwd: playgroundDirectory,

--- a/playground/relative/tsconfig.json
+++ b/playground/relative/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "target": "ESNext",
+    "jsx": "preserve",
+    "module": "ESNext",
+    "types": ["node"]
+  },
+  "exclude": [
+    "dist"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,31 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  playground/relative:
+    dependencies:
+      '@yeskunall/astro-umami':
+        specifier: workspace:*
+        version: link:../../packages/astro-umami
+      astro:
+        specifier: 7.1.6
+        version: 7.1.6(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.59.0)(yaml@2.8.2)
+    devDependencies:
+      '@astrojs/check':
+        specifier: 0.9.10
+        version: 0.9.10(prettier@3.7.4)(typescript@6.0.3)
+      '@playwright/test':
+        specifier: 1.62.0
+        version: 1.62.0
+      '@types/node':
+        specifier: 26.1.2
+        version: 26.1.2
+      playwright:
+        specifier: 1.62.0
+        version: 1.62.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   playground/umami-enabled:
     dependencies:
       '@yeskunall/astro-umami':


### PR DESCRIPTION
Allow `endpointUrl` to be a relative path (e.g., `/_umami`) for proxied Umami instances served from a subdirectory. When using relative paths, the script `src` becomes relative and `data-host-url` is only set when explicitly provided.

Closes #139.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endpoint URLs now support absolute URLs and root-relative paths.
  * Relative endpoints load tracking scripts from the current site origin.
  * Absolute endpoints use the configured host when loading tracking scripts.

* **Bug Fixes**
  * Trailing slashes are handled consistently.
  * Invalid or unsupported endpoint formats now produce clear errors.
  * Endpoint values are safely escaped to prevent script injection issues.

* **Tests**
  * Added coverage for relative endpoints, invalid URL formats, request routing, and script-safety scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->